### PR TITLE
Firehose -> Hydrant in README, package.json, and package-lock.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Firehose
+# Hydrant
 
 ## Setup
 
@@ -44,14 +44,14 @@ Let's say you're updating from e.g. Spring 2023 to Fall 2023.
 
 *I want to change...*
 
-- *...the data available to Firehose.*
+- *...the data available to Hydrant.*
   - The entry point is `scrapers/update.py`.
   - This goes through `src/components/App.tsx`, which looks for the data.
-  - The exit point is through the constructor of `Firehose` in `src/lib/firehose.ts`.
-- *...the way Firehose behaves.*
+  - The exit point is through the constructor of `Hydrant` in `src/lib/firehose.ts`.
+- *...the way Hydrant behaves.*
   - The entry point is `src/lib/firehose.ts`.
-  - The exit point is through `src/components/App.tsx`, which constructs `Firehose` and passes it down.
-- *...the way Firehose looks.*
+  - The exit point is through `src/components/App.tsx`, which constructs `Hydrant` and passes it down.
+- *...the way Hydrant looks.*
   - The entry point is `src/components/App.tsx`.
   - We use [Chakra UI](https://chakra-ui.com/) as our component library. Avoid writing CSS.
 
@@ -64,4 +64,4 @@ Try to introduce as few technologies as possible to keep this mostly future-proo
 - it's tiny and used in only a small part of the app
   - e.g. msgpack-lite is only used for URL encoding, nanoid is only used to make IDs
 - it's a big, popular, well-documented project that's been around for several years
-  - e.g. FullCalendar has been around since old Firehose, Chakra UI has a large community
+  - e.g. FullCalendar has been around since old Hydrant, Chakra UI has a large community

--- a/README.md
+++ b/README.md
@@ -64,4 +64,4 @@ Try to introduce as few technologies as possible to keep this mostly future-proo
 - it's tiny and used in only a small part of the app
   - e.g. msgpack-lite is only used for URL encoding, nanoid is only used to make IDs
 - it's a big, popular, well-documented project that's been around for several years
-  - e.g. FullCalendar has been around since old Hydrant, Chakra UI has a large community
+  - e.g. FullCalendar has been around since 2010, Chakra UI has a large community

--- a/deploy.sh
+++ b/deploy.sh
@@ -2,4 +2,4 @@ unmount
 sitemnt
 rm -rf build/old_www
 rm -rf build/semesters
-cp -r build/. /mnt/site/firehose-beta
+cp -r build/. /mnt/site/hydrant-beta

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "firehose",
+  "name": "hydrant",
   "version": "0.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "firehose",
+      "name": "hydrant",
       "version": "0.1.0",
       "dependencies": {
         "@ag-grid-community/client-side-row-model": "^28.1.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "firehose",
+  "name": "hydrant",
   "homepage": ".",
   "version": "0.1.0",
   "private": true,


### PR DESCRIPTION
Updates as mentioned in #8. Only setback is README still mentions `firehose.ts`; will update that when the Firehose class is updated (also as mentioned in #8). 